### PR TITLE
Make Appveyor agent download URL using HTTPS instead of HTTP.

### DIFF
--- a/resources/agent_install.rb
+++ b/resources/agent_install.rb
@@ -21,7 +21,7 @@ resource_name :appveyor_agent
 property :version, String, name_property: true
 property :access_key, String, required: true
 property :deployment_group, required: true
-property :installer_url, String, default: lazy { "http://www.appveyor.com/downloads/deployment-agent/#{version}/AppveyorDeploymentAgent.msi" }
+property :installer_url, String, default: lazy { "https://www.appveyor.com/downloads/deployment-agent/#{version}/AppveyorDeploymentAgent.msi" }
 property :install_path, String, default: lazy { 'C:\\Program Files (x86)\\AppVeyor\\DeploymentAgent\\Appveyor.DeploymentAgent.Service.exe' }
 
 action :create do


### PR DESCRIPTION
This PR just changes the default URL to HTTPS for the downloading of the Appveyor agent.  This is beneficial for sites where HTTPS only is allowed, and HTTP is blocked.